### PR TITLE
chore: add type hints

### DIFF
--- a/arbys.ts
+++ b/arbys.ts
@@ -20,21 +20,21 @@ declare let currentHour: number;
 const days = [ "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat" ];
 const months = [ "January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December" ];
 
-function loc(key)
+function loc(key: string): string
 {
 	return dict[key] ?? key;
 }
 
-function totwo(num)
+function totwo(num: number): string
 {
 	if (num < 10)
 	{
 		return "0" + num;
 	}
-	return num;
+	return num.toString();
 }
 
-function formattz(offset)
+function formattz(offset: number): string
 {
 	if (offset == 0)
 	{
@@ -49,7 +49,7 @@ function formattz(offset)
 }
 document.getElementById("local-time-option").textContent += " (" + formattz(new Date().getTimezoneOffset()) + ")";
 
-function formathour(hour)
+function formathour(hour: number): string
 {
 	switch ((document.getElementById("select-hourfmt") as HTMLSelectElement).value)
 	{
@@ -111,7 +111,7 @@ Promise.all([
 	onLanguageUpdate();
 });
 
-function updateFilterNamesForLocale()
+function updateFilterNamesForLocale(): void
 {
 	document.querySelector("label[for=filter-MT_SURVIVAL]").textContent = toTitleCase(dict["/Lotus/Language/Missions/MissionName_Survival"]);
 	document.querySelector("label[for=filter-MT_DEFENSE]").textContent = toTitleCase(dict["/Lotus/Language/Missions/MissionName_Defense"]);
@@ -132,7 +132,7 @@ function updateFilterNamesForLocale()
 	document.querySelector("label[for=filter-FC_MITW]").textContent = dict["/Lotus/Language/Game/Faction_MITW"];
 }
 
-function updateLog()
+function updateLog(): void
 {
 	console.time("updateLog");
 
@@ -281,7 +281,7 @@ function updateLog()
 	console.timeEnd("updateLog");
 }
 
-function saveSettings()
+function saveSettings(): void
 {
 	let hash = "days=" + encodeURIComponent((document.getElementById("select-days") as HTMLSelectElement).value)
 			+ "&tz=" + encodeURIComponent((document.getElementById("select-tz") as HTMLSelectElement).value)

--- a/index.ts
+++ b/index.ts
@@ -69,7 +69,7 @@ if (params.has("q"))
 	document.getElementById("results-status").textContent = "Loading...";
 }
 
-(document.getElementById("query") as HTMLInputElement).oninput = function(this: HTMLInputElement)
+(document.getElementById("query") as HTMLInputElement).oninput = function(this: HTMLInputElement): void
 {
 	if (this.value == "")
 	{
@@ -191,7 +191,7 @@ Promise.all([
 		doQuery((document.getElementById("query") as HTMLInputElement).value);
 	}
 
-	document.getElementById("query").oninput = function(this: HTMLInputElement)
+	document.getElementById("query").oninput = function(this: HTMLInputElement): void
 	{
 		if (this.value == "")
 		{
@@ -220,7 +220,7 @@ Promise.all([
 	};
 });
 
-function updateMissionDeckNames()
+function updateMissionDeckNames(): void
 {
 	window.missionDeckNames = {
 		"/Lotus/Types/Game/MissionDecks/SortieRewards": ["Sortie"],
@@ -259,7 +259,7 @@ function updateMissionDeckNames()
 	});
 }
 
-function doQuery(query: string)
+function doQuery(query: string): void
 {
 	console.time("Input to language tags");
 	let results = getDictEntriesFromQuery(query).reduce((arr, [key, value]) =>
@@ -780,7 +780,7 @@ function getDictEntriesFromQuery(query: string): [string, string][]
 	});
 }
 
-function resolveTagsToUses(results)
+function resolveTagsToUses(results: { type: string; key: string; value: any }[]): { type: string; key: string; value: any }[]
 {
 	const res = [];
 	outer: for (const result of results)
@@ -802,7 +802,7 @@ function resolveTagsToUses(results)
 	return res;
 }
 
-function addUniqueNameResults(res, query)
+function addUniqueNameResults(res: { type: string; key: string; value: any }[], query: string): void
 {
 	query = query.toLowerCase();
 	for (const [type, entries] of Object.entries(window.meta_entries))

--- a/live.ts
+++ b/live.ts
@@ -2,11 +2,11 @@ import type { IChallenge, IFaction, IMissionType, IRegion, TFaction, TMissionTyp
 
 // Oracle
 interface IBountyCycle {
-    expiry:         number;
-    rot:            string;
-    vaultRot:       string;
-    zarimanFaction: string;
-    bounties:       Record<string, {
+	expiry:         number;
+	rot:            string;
+	vaultRot:       string;
+	zarimanFaction: string;
+	bounties:       Record<string, {
 		node:      string;
 		challenge: string;
 		ally?:     string;
@@ -16,22 +16,22 @@ interface IBountyCycle {
 // Oracle
 interface IWeekly {
 	expiry:                    number;
-    labConquestMissions:       IConquestMission[];
-    labConquestFrameVariables: string[];
-    hexConquestMissions:       IConquestMission[];
-    hexConquestFrameVariables: string[];
+	labConquestMissions:       IConquestMission[];
+	labConquestFrameVariables: string[];
+	hexConquestMissions:       IConquestMission[];
+	hexConquestFrameVariables: string[];
 }
 interface IConquestMission {
 	type:       string;
-    variant:    string;
-    conditions: string[];
+	variant:    string;
+	conditions: string[];
 }
 
 // Oracle
 interface IInvasions {
 	activation: number;
-    expiry:     number;
-    invasions: IInvasion[];
+	expiry:     number;
+	invasions: IInvasion[];
 }
 interface IInvasion {
 	id:       string;
@@ -47,8 +47,8 @@ interface IInvasion {
 // worldState
 interface IMongoDate {
 	$date: {
-        $numberLong: string;
-    };
+		$numberLong: string;
+	};
 }
 
 // worldState
@@ -57,10 +57,10 @@ interface IDailyDeal {
 	Activation: IMongoDate;
 	Expiry: IMongoDate;
 	Discount: number;
-    OriginalPrice: number;
-    SalePrice: number;
-    AmountTotal: number;
-    AmountSold: number;
+	OriginalPrice: number;
+	SalePrice: number;
+	AmountTotal: number;
+	AmountSold: number;
 }
 
 // common.js
@@ -112,7 +112,7 @@ declare global {
 				Variants: {
 					missionType: TMissionType;
 					modifierType: string;
-        			node: string;
+					node: string;
 				}[];
 			}[];
 			LiteSorties: {
@@ -122,12 +122,12 @@ declare global {
 				Boss: "SORTIE_BOSS_AMAR" | "SORTIE_BOSS_NIRA" | "SORTIE_BOSS_BOREAL";
 				Missions: {
 					missionType: TMissionType;
-        			node: string;
+					node: string;
 				}[];
 			}[];
 			ActiveMissions: {
 				_id: { $oid: string };
-    			Region: number;
+				Region: number;
 				Seed: number;
 				Activation: IMongoDate;
 				Expiry: IMongoDate;
@@ -140,7 +140,7 @@ declare global {
 				_id: { $oid: string };
 				Activation: IMongoDate;
 				Expiry: IMongoDate;
-    			Node: string;
+				Node: string;
 				Manifest: {
 					ItemType: string;
 					PrimePrice: number;
@@ -192,7 +192,7 @@ ExportChallenges_promise.then(res => { (window as any).ExportChallenges = res; }
 ExportMissionTypes_promise.then(res => { (window as any).ExportMissionTypes = res; });
 ExportFactions_promise.then(res => { (window as any).ExportFactions = res; });
 
-function formatExpiry(expiry)
+function formatExpiry(expiry: number): string
 {
 	expiry -= expiry % 1000; expiry += 1000; // normalise the ms so everything ticks at the same time
 	const time = Date.now();
@@ -204,7 +204,7 @@ function formatExpiry(expiry)
 	return deltaToUnits(delta).join(" ");
 }
 
-function deltaToUnits(delta)
+function deltaToUnits(delta: number): string[]
 {
 	delta = Math.abs(delta);
 
@@ -228,12 +228,12 @@ function deltaToUnits(delta)
 	return units;
 }
 
-function formatActivation(activation)
+function formatActivation(activation: number): string
 {
 	return deltaToUnits(Date.now() - activation)[0];
 }
 
-function createExpiryBadge(expiry)
+function createExpiryBadge(expiry: number): HTMLSpanElement
 {
 	const span = document.createElement("span");
 	span.setAttribute("data-expiry", expiry);
@@ -242,7 +242,7 @@ function createExpiryBadge(expiry)
 	return span;
 }
 
-function setDatum(name, value, expiry)
+function setDatum(name: string, value: string, expiry: number): void
 {
 	const elm = document.getElementById(name);
 	elm.querySelectorAll("[data-bs-toggle=tooltip]").forEach(x => window.bootstrap.Tooltip.getInstance(x).dispose());
@@ -250,7 +250,7 @@ function setDatum(name, value, expiry)
 	elm.appendChild(createExpiryBadge(expiry));
 }
 
-function updateVallis()
+function updateVallis(): void
 {
 	const EPOCH = new Date("November 10, 2018 08:13:48 UTC").getTime();
 	const time = Date.now();
@@ -264,7 +264,7 @@ function updateVallis()
 }
 updateVallis();
 
-function updateDuviriMoodLocalised()
+function updateDuviriMoodLocalised(): void
 {
 	setDatum("duviri", osdict[[
 		"/Lotus/Language/Duviri/SadMoodTitleShort",
@@ -275,7 +275,7 @@ function updateDuviriMoodLocalised()
 	][window.duviri_mood_index % 5]], window.duviri_expiry);
 }
 
-function updateDuviriMood()
+function updateDuviriMood(): void
 {
 	const moodIndex = Math.trunc(Date.now() / 7200000);
 	const moodStart = moodIndex * 7200000;
@@ -290,7 +290,7 @@ function updateDuviriMood()
 osdict_promise.then(() => updateDuviriMood());
 
 let sundown_update_queued = false;
-function updateDayNightCycle()
+function updateDayNightCycle(): void
 {
 	const time = Date.now();
 	const cycleNightStart = window.bountyCycleExpiry - 3_000_000;
@@ -338,7 +338,7 @@ const allyNames = {
 	"/Lotus/Types/Gameplay/1999Wf/ProtoframeAllies/QuincyAllyAgent": "Quincy",
 };
 
-function updateBountyCycleLocalised()
+function updateBountyCycleLocalised(): void
 {
 	document.getElementById("bounty-rot-rewards").textContent = rotRewards[window.bountyCycle.rot].map(x => dict[x]).join(", ");
 	document.getElementById("vault-rot-rewards").textContent = vaultRotRewards[window.bountyCycle.vaultRot].map(x => dict[x]).join(", ");
@@ -370,7 +370,7 @@ function updateBountyCycleLocalised()
 	}
 }
 
-function updateBountyCycle()
+function updateBountyCycle(): void
 {
 	window.refresh_bounty_cycle_at = undefined;
 	fetch("https://oracle.browse.wf/bounty-cycle").then(res => res.json()).then(async (bountyCycle: IBountyCycle) =>
@@ -397,7 +397,7 @@ function updateBountyCycle()
 	});
 }
 
-function updateNames()
+function updateNames(): void
 {
 	document.getElementById("poe-name").textContent = dict["/Lotus/Language/Locations/EidolonPlains"] + " / " + dict["/Lotus/Language/Locations/Earth"];
 	document.getElementById("vallis-name").textContent = dict["/Lotus/Language/Locations/VenusLandscape"];
@@ -409,7 +409,7 @@ function updateNames()
 	document.getElementById("ZarimanSyndicate-name").textContent = dict["/Lotus/Language/Syndicates/ZarimanName"];
 }
 
-async function updateArbyLocalised()
+async function updateArbyLocalised(): Promise<void>
 {
 	// dicts are guaranteed available here
 	await ExportFactions_promise;
@@ -419,7 +419,7 @@ async function updateArbyLocalised()
 	document.getElementById("arby-where").textContent = "@ " + dict[window.arby_node.name] + ", " + dict[window.arby_node.systemName];
 }
 
-function updateArby()
+function updateArby(): void
 {
 	// dicts are guaranteed available here
 
@@ -434,7 +434,7 @@ function updateArby()
 	setTimeout(updateArby, window.arby_expiry - Date.now());
 }
 
-async function updateIncursionsLocalised()
+async function updateIncursionsLocalised(): Promise<void>
 {
 	// dicts are guaranteed available here
 	await ExportFactions_promise;
@@ -456,7 +456,7 @@ async function updateIncursionsLocalised()
 	}
 }
 
-function updateIncursions()
+function updateIncursions(): void
 {
 	const today = Math.trunc(Date.now() / 86400000) * 86400;
 	const epochDay = window.incursions[0][0];
@@ -466,14 +466,14 @@ function updateIncursions()
 	setTimeout(updateIncursions, window.incursions_expiry - Date.now());
 }
 
-function addTooltip(elm, title)
+function addTooltip(elm: HTMLElement, title: string): any
 {
 	elm.setAttribute("data-bs-toggle", "tooltip");
 	elm.setAttribute("data-bs-title", title);
 	return new window.bootstrap.Tooltip(elm);
 }
 
-function updateWeeklyLocalised()
+function updateWeeklyLocalised(): void
 {
 	{
 		setDatum("labConquest-header", osdict["/Lotus/Language/Conquest/SolarMapLabConquestNode"], window.refresh_weekly_at);
@@ -590,7 +590,7 @@ function updateWeeklyLocalised()
 	}
 }
 
-function updateWeekly()
+function updateWeekly(): void
 {
 	window.refresh_weekly_at = undefined;
 	Promise.all([
@@ -636,7 +636,7 @@ function updateWeekly()
 	});
 }
 
-function updateNewsTicker()
+function updateNewsTicker(): void
 {
 	let highest_time = 0;
 	const items = [];
@@ -739,7 +739,7 @@ function updateNewsTicker()
 	document.querySelector("#news-body > :last-child").classList.remove("mb-1");
 }
 
-async function updateNewsSources()
+async function updateNewsSources(): Promise<void>
 {
 	window.refresh_news_sources_at = undefined;
 
@@ -799,7 +799,7 @@ async function updateNewsSources()
 	}
 }
 
-function updateWorldStateLocalised()
+function updateWorldStateLocalised(): void
 {
 	updateNewsTicker();
 	updateSorties();
@@ -811,7 +811,7 @@ function updateWorldStateLocalised()
 	updateFissures();
 }
 
-function updateWorldState()
+function updateWorldState(): void
 {
 	window.refresh_world_state_at = undefined;
 	fetch("https://oracle.browse.wf/worldState.json?" + Date.now()).then(res => res.json()).then(worldState =>
@@ -871,7 +871,7 @@ const sortieModifiers = {
 	"SORTIE_MODIFIER_BOW_ONLY": "Bow Only",
 };
 
-function setWorldStateExpiry(expiry)
+function setWorldStateExpiry(expiry: number): void
 {
 	if (Date.now() > expiry)
 	{
@@ -884,7 +884,7 @@ function setWorldStateExpiry(expiry)
 	}
 }
 
-async function updateSorties()
+async function updateSorties(): Promise<void>
 {
 	await dicts_promise;
 	await ExportMissionTypes_promise;
@@ -932,7 +932,7 @@ async function updateSorties()
 	document.getElementById("litesortie-body").innerHTML += " • " + mission_names.join(", ");
 }
 
-function updateKinePage()
+function updateKinePage(): void
 {
 	const Tmp = JSON.parse(window.worldState.Tmp ?? "{}");
 	const lang_code = (localStorage.getItem("lang") ?? "en");
@@ -942,7 +942,7 @@ function updateKinePage()
 	}
 }
 
-async function updateDarvosDeal()
+async function updateDarvosDeal(): Promise<void>
 {
 	window.dailyDeal = window.worldState.DailyDeals.find(x => Date.now() >= parseInt(x.Activation.$date.$numberLong) && Date.now() < parseInt(x.Expiry.$date.$numberLong));
 	setDatum("darvo-header", "Darvo's Deal", window.dailyDeal.Expiry.$date.$numberLong);
@@ -966,7 +966,7 @@ async function updateDarvosDeal()
 	window.last_darvo_deal = window.dailyDeal.Activation.$date.$numberLong;
 }
 
-async function updateBaro()
+async function updateBaro(): Promise<void>
 {
 	await dicts_promise;
 	await ExportRegions_promise;
@@ -1051,7 +1051,7 @@ async function updateBaro()
 	}
 }
 
-async function updateAlerts()
+async function updateAlerts(): Promise<void>
 {
 	if (window.worldState.Alerts.length != 0)
 	{
@@ -1138,7 +1138,7 @@ async function updateAlerts()
 	window.last_alert_count = window.worldState.Alerts.length;
 }
 
-async function updateGoals()
+async function updateGoals(): Promise<void>
 {
 	if (window.worldState.Goals.length != 0)
 	{
@@ -1156,7 +1156,7 @@ async function updateGoals()
 	}
 }
 
-function updateTeshin()
+function updateTeshin(): void
 {
 	const EPOCH = 1736121600 * 1000;
 	const week = Math.trunc((Date.now() - EPOCH) / 604800000);
@@ -1211,7 +1211,7 @@ const weaponChoices = [
 	["/Lotus/Language/Items/RifleName", "/Lotus/Language/Items/PistolName", "/Lotus/Language/Items/LongSwordName", "/Lotus/Language/Items/HuntingBowName", "/Lotus/Language/Items/KunaiName"]
 ];
 
-function updateCircuitLocalised()
+function updateCircuitLocalised(): void
 {
 	const EPOCH = 1734307200 * 1000;
 	const week = Math.trunc((Date.now() - EPOCH) / 604800000);
@@ -1219,7 +1219,7 @@ function updateCircuitLocalised()
 	document.getElementById("circuit-weapons").textContent = [...weaponChoices[week % weaponChoices.length]].map(x => dict[x]).join(" · ") + " ";
 }
 
-function updateCircuit()
+function updateCircuit(): void
 {
 	const EPOCH = 1734307200 * 1000;
 	const week = Math.trunc((Date.now() - EPOCH) / 604800000);
@@ -1266,7 +1266,7 @@ function updateCircuit()
 }
 dict_promise.then(updateCircuit);
 
-function loadScriptPromise(src)
+function loadScriptPromise(src: string): Promise<void>
 {
 	return new Promise((resolve, reject) =>
 	{
@@ -1279,17 +1279,17 @@ function loadScriptPromise(src)
 }
 
 const item_data_promises = {};
-function getItemDataPromise(uniqueName)
+function getItemDataPromise(uniqueName: string): Promise<any>
 {
-	uniqueName = uniqueName.split("/Lotus/StoreItems/").join("/Lotus/");
-	if (!item_data_promises[uniqueName])
-	{
-		item_data_promises[uniqueName] = fetch("https://browse.wf" + uniqueName).then(res => res.json());
-	}
-	return item_data_promises[uniqueName];
+		uniqueName = uniqueName.split("/Lotus/StoreItems/").join("/Lotus/");
+		if (!item_data_promises[uniqueName])
+		{
+				item_data_promises[uniqueName] = fetch("https://browse.wf" + uniqueName).then(res => res.json());
+		}
+		return item_data_promises[uniqueName];
 }
 
-async function getItemNamePromise(uniqueName)
+async function getItemNamePromise(uniqueName: string): Promise<string>
 {
 	try
 	{
@@ -1313,13 +1313,13 @@ async function getItemNamePromise(uniqueName)
 	}
 }
 
-function isOidMarkedAsCompleted(oid)
+function isOidMarkedAsCompleted(oid: string): boolean
 {
 	const arr = JSON.parse(localStorage.getItem("oids_completed") ?? "[]");
 	return arr.findIndex(x => x == oid) != -1;
 }
 
-function toggleOidCompletion(oid)
+function toggleOidCompletion(oid: string): void
 {
 	const arr = JSON.parse(localStorage.getItem("oids_completed") ?? "[]");
 	const index = arr.findIndex(x => x == oid);
@@ -1334,7 +1334,7 @@ function toggleOidCompletion(oid)
 	localStorage.setItem("oids_completed", JSON.stringify(arr));
 }
 
-function createCompletionToggle(oid)
+function createCompletionToggle(oid: string): HTMLAnchorElement
 {
 	let what = "completed";
 	if (oid.substr(0, 5) == "kahlb")
@@ -1355,7 +1355,7 @@ function createCompletionToggle(oid)
 	return a;
 }
 
-async function updateInvasionsLocalised()
+async function updateInvasionsLocalised(): Promise<void>
 {
 	const tbody = document.createElement("tbody");
 	let last_id = "";
@@ -1419,7 +1419,7 @@ async function updateInvasionsLocalised()
 	document.getElementById("invasions-table").appendChild(tbody);
 }
 
-function updateInvasions()
+function updateInvasions(): void
 {
 	window.refresh_invasions_at = undefined;
 	fetch("https://oracle.browse.wf/invasions").then(res => res.json()).then(async (res: IInvasions) =>
@@ -1442,7 +1442,7 @@ function updateInvasions()
 	});
 }
 
-function setFissuresExpiry(expiry)
+function setFissuresExpiry(expiry: number): void
 {
 	if (!window.refresh_fissures_at || window.refresh_fissures_at > expiry)
 	{
@@ -1459,7 +1459,7 @@ const fissureTiers = {
 	VoidT6: "Omnia",
 };
 
-async function updateFissures()
+async function updateFissures(): Promise<void>
 {
 	await dict_promise;
 	await ExportRegions_promise;
@@ -1647,7 +1647,7 @@ setInterval(function()
 	}
 }, 500);
 
-function refreshCollapseStatus(elm)
+function refreshCollapseStatus(elm: HTMLElement): void
 {
 	const engaged = localStorage.getItem("live.collapse." + elm.getAttribute("data-collapse-toggle"));
 	const span = document.createElement("span");
@@ -1684,7 +1684,7 @@ document.querySelectorAll<HTMLSpanElement>("[data-collapse-toggle]").forEach(elm
 	};
 });
 
-function sendNotification(text)
+function sendNotification(text: string): void
 {
 	const toast = document.createElement("div");
 	toast.className = "toast align-items-center text-bg-primary border-0";
@@ -1707,7 +1707,7 @@ function sendNotification(text)
 	}
 }
 
-function refreshNotifStatus(elm)
+function refreshNotifStatus(elm: HTMLElement): void
 {
 	const enabled = localStorage.getItem("live.notif." + elm.getAttribute("data-notif-toggle"));
 	const span = document.createElement("span");

--- a/prime-vault.ts
+++ b/prime-vault.ts
@@ -30,7 +30,25 @@ Promise.all([
 	fetch("https://browse.wf/warframe-public-export-plus/ExportWarframes.json").then(res => res.json()),
 	fetch("https://browse.wf/warframe-public-export-plus/ExportSentinels.json").then(res => res.json()),
 	fetch("https://raw.githubusercontent.com/calamity-inc/warframe-worldstate-history/senpai/worldState.json").then(res => res.json()),
-	]).then(function([ dict, ExportRelics, ExportRewards, ExportRecipes, ExportWeapons, ExportWarframes, ExportSentinels, worldState ])
+	]).then(function([
+		dict,
+		ExportRelics,
+		ExportRewards,
+		ExportRecipes,
+		ExportWeapons,
+		ExportWarframes,
+		ExportSentinels,
+		worldState
+	]: [
+		Record<string, string>,
+		Record<string, IRelic>,
+		Record<string, TMissionDeck>,
+		Record<string, IRecipe>,
+		Record<string, IWeapon>,
+		Record<string, IPowersuit>,
+		Record<string, ISentinel>,
+		any
+	]): void
 {
 	(window as any).dict = dict;
 	//(window as any).ExportRelics = ExportRelics;
@@ -104,7 +122,7 @@ Promise.all([
 	onLanguageUpdate = updateList;
 });
 
-function updateList()
+function updateList(): void
 {
 	const state_to_elm: Record<TState, HTMLDivElement> = {
 		[STATE_VAULTED]: document.getElementById("vaulted") as HTMLDivElement,

--- a/profile.ts
+++ b/profile.ts
@@ -72,12 +72,12 @@ const platformNames = {
 	"mob": "Mobile",
 };
 
-function peColourToHex(colour)
+function peColourToHex(colour: { value: string }): string
 {
 	return "#" + colour.value.substr(4);
 }
 
-function peColourToRgb(colour)
+function peColourToRgb(colour: { value: string }): [number, number, number]
 {
 	return [
 		parseInt(colour.value.substr(4, 2), 16),
@@ -86,7 +86,7 @@ function peColourToRgb(colour)
 	];
 }
 
-function parseRgbaInt(val)
+function parseRgbaInt(val: number): [number, number, number, number]
 {
 	return [
 		(val >> 16) & 0xff,
@@ -96,19 +96,19 @@ function parseRgbaInt(val)
 	];
 }
 
-function toHexString(r, g, b)
+function toHexString(r: number, g: number, b: number): string
 {
 	return "#" + (r.toString(16).padStart(2, "0") + g.toString(16).padStart(2, "0") + b.toString(16).padStart(2, "0")).toUpperCase();
 }
 
-function makeColourFilter(colour)
+function makeColourFilter(colour: { value: string }): string
 {
 	const [red, green, blue] = peColourToRgb(colour);
 	const svg = `<svg xmlns="http://www.w3.org/2000/svg"><filter id="a"><feColorMatrix color-interpolation-filters="sRGB" in="SourceGraphic" type="matrix" values="${red / 255} 0 0 0 0 0 ${green / 255} 0 0 0 0 0 ${blue / 255} 0 0 0 0 0 1 0" /></filter></svg>`;
 	return "url('data:image/svg+xml," + svg + "#a')";
 }
 
-function makeSyndicateLogoElement(syndicate)
+function makeSyndicateLogoElement(syndicate: { backgroundColour: { value: string }; icon: string; colour: { value: string } }): HTMLDivElement
 {
 	const div = document.createElement("div");
 	div.style.backgroundColor /* [sic] */ = peColourToHex(syndicate.backgroundColour);
@@ -187,17 +187,17 @@ Promise.all([
 	}
 });
 
-function isXplatName(name)
+function isXplatName(name: string): boolean
 {
 	return name.charCodeAt(name.length - 1) >= 0xE000;
 }
 
-function xplatNameToPlatformId(name)
+function xplatNameToPlatformId(name: string): number
 {
 	return name.charCodeAt(name.length - 1) - 0xE000;
 }
 
-function sanitiseName(name)
+function sanitiseName(name: string): string
 {
 	if (name.charCodeAt(name.length - 1) >= 0xE000)
 	{
@@ -206,7 +206,7 @@ function sanitiseName(name)
 	return name;
 }
 
-function loadProfile(file)
+function loadProfile(file?: File): void
 {
 	if (!file)
 	{
@@ -238,7 +238,7 @@ function loadProfile(file)
 	reader.readAsText(file);
 }
 
-function renderProfile()
+function renderProfile(): void
 {
 	document.querySelector("#status").classList.add("d-none");
 
@@ -705,7 +705,7 @@ function renderProfile()
 	}
 }
 
-function displaySkin(category, i, value)
+function displaySkin(category: string, i: number, value: string): void
 {
 	const elm = document.getElementById(category + "-skin-" + i);
 	if (elm)
@@ -753,7 +753,7 @@ const modularWeapons = {
 	"/Lotus/Weapons/Ostron/Melee/LotusModularWeapon": "Zaw",
 };
 
-function updateFashion()
+function updateFashion(): void
 {
 	for (const category of ["Suits", "LongGuns", "Pistols", "Melee"])
 	{
@@ -840,7 +840,7 @@ function updateFashion()
 	}
 }
 
-function tabulate(elm, event)
+function tabulate(elm: HTMLElement, event: Event): void
 {
 	event.preventDefault();
 
@@ -852,7 +852,7 @@ function tabulate(elm, event)
 	}
 }
 
-function activateTab(id)
+function activateTab(id: string): void
 {
 	document.querySelectorAll("[data-tab]").forEach(x => x.classList.remove("active"));
 	document.querySelector("[data-tab="+id+"]").classList.add("active");


### PR DESCRIPTION
## Summary
- add explicit parameter and return types to TypeScript functions

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit` *(fails: Property 'showdown' does not exist on type 'Window & typeof globalThis'.)*

------
https://chatgpt.com/codex/tasks/task_e_68c18b368e5883259fb034a8f1b4898a